### PR TITLE
Correção da configuração do loadpath no gemspec

### DIFF
--- a/api_moip_assinaturas.gemspec
+++ b/api_moip_assinaturas.gemspec
@@ -1,3 +1,6 @@
+# -*- encoding: utf-8 -*-
+$:.push File.expand_path("../lib", __FILE__)
+require "api-moip-assinaturas/version"
 Gem::Specification.new do |s|
   s.name        = 'api-moip-assinaturas'
   s.version     = '0.1.3'
@@ -15,4 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'httparty', '~> 0.11.0', '>= 0.11.0'
   s.add_development_dependency 'json', '~> 1.7.7', '>= 1.7.7'
   s.add_development_dependency 'activemodel', '~> 3.2.12', '>= 3.2.12'
+  s.add_dependency 'httparty', '>= 0.11.0'
+  s.add_dependency 'json', '>= 1.7.7'
+  s.add_dependency 'activemodel', '>= 3.2.12'
 end


### PR DESCRIPTION
Cara eu criei um projeto chamado foo

<pre>
    rails new foo
</pre>


Com um gemfile assim:

<pre>
    source 'https://rubygems.org'
    gem 'rails', '3.2.13'
    gem 'sqlite3'
    gem 'api-moip-assinaturas', '~> 0.1.3',  :git => 'git@github.com:paulopatto/api-moip-assinaturas.git', :branch => :bugfix
    gem 'pry-rails'
    group :assets do
    gem 'sass-rails',   '~> 3.2.3'
    gem 'coffee-rails', '~> 3.2.1'
    gem 'therubyracer', :platforms => :ruby
    gem 'uglifier', '>= 1.0.3'
    gem 'jquery-rails'
    end
</pre>


E adicionei a seguinte configuração no application.rb

<pre>
    require 'moip'
</pre>


Logo abaixo do require rails. E obtive sucesso com:

<pre>
    paulopatto@csspl03l ~/Code/foo $ rails c
    Loading development environment (Rails 3.2.13)
    [1] pry(main)> Moip
    => Moip
    [2] pry(main)> Moip::Payment
    => Moip::Payment
    [3] pry(main)>
</pre>
