### PR TITLE
Corrige a condição do case do método full_status de Invoice

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    api-moip-assinaturas (0.2.31)
+    api-moip-assinaturas (0.2.30)
       activemodel (>= 3.2.12)
       httparty (>= 0.11.0)
       i18n (~> 0.6.1, >= 0.6.1)

--- a/api_moip_assinaturas.gemspec
+++ b/api_moip_assinaturas.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'api-moip-assinaturas'
-  s.version     = '0.2.32'
+  s.version     = '0.2.31'
   s.date        = '2013-07-02'
   s.summary     = "Moip Assinaturas by Pixxel"
   s.description = "Gem desenvolvida para atender aos requisitos do moip api de assinaturas"

--- a/lib/moip/models/invoice.rb
+++ b/lib/moip/models/invoice.rb
@@ -31,7 +31,7 @@ class Moip::Invoice < Moip::Model
 	end
 
 	def full_status
-		status = case self.status
+		status = case self.status['code']
 			when 1 then "Em aberto" # A fatura foi gerada mas ainda não foi paga pelo assinante.
 			when 2 then "Aguardando Confirmação" # A fatura foi paga pelo assinante, mas o pagamento está em processo de análise de risco.
 			when 3 then "Pago" # A fatura foi paga pelo assinante e confirmada.

--- a/lib/moip/models/invoice.rb
+++ b/lib/moip/models/invoice.rb
@@ -31,7 +31,7 @@ class Moip::Invoice < Moip::Model
 	end
 
 	def full_status
-		status = case self.status
+		status = case self.status[:code]
 			when 1 then "Em aberto" # A fatura foi gerada mas ainda não foi paga pelo assinante.
 			when 2 then "Aguardando Confirmação" # A fatura foi paga pelo assinante, mas o pagamento está em processo de análise de risco.
 			when 3 then "Pago" # A fatura foi paga pelo assinante e confirmada.

--- a/lib/moip/models/invoice.rb
+++ b/lib/moip/models/invoice.rb
@@ -31,7 +31,7 @@ class Moip::Invoice < Moip::Model
 	end
 
 	def full_status
-		status = case self.status[:code]
+		status = case self.status
 			when 1 then "Em aberto" # A fatura foi gerada mas ainda não foi paga pelo assinante.
 			when 2 then "Aguardando Confirmação" # A fatura foi paga pelo assinante, mas o pagamento está em processo de análise de risco.
 			when 3 then "Pago" # A fatura foi paga pelo assinante e confirmada.

--- a/lib/moip/models/plan.rb
+++ b/lib/moip/models/plan.rb
@@ -45,7 +45,7 @@ class Moip::Plan < Moip::Model
 	def plans= hash
 		@plans = []
 		hash.each do |e|
-			plan = Moip::Plan.new
+			plan = self.class.new
 			plan.set_parameters e
 			@plans << plan
 		end


### PR DESCRIPTION
A condição era um hash com uma descrição e um código, porém dentro do case deve ser testado o campo `code`.
